### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#PHPunctional: Functional Programming Library For PHP#
+# PHPunctional: Functional Programming Library For PHP #
 
 **Actual documentation and more examples coming soon**
 
 This library was created as a test to see how far I could push PHP into the functional programming territory... and
 to be honest I'm surprised with the result.
 
-##Highlights:##
+## Highlights: ##
 - Validation Applicative
 - Maybe Monad
 - Either Monad
@@ -14,9 +14,9 @@ to be honest I'm surprised with the result.
 
 Some [examples](https://github.com/r-cyr/PHPunctional/tree/master/P/Examples) are available
 
-##Remaining things to do:##
+## Remaining things to do: ##
 - Documentation in Markdown format
 - More comments in code
 - Tests for Arithmetic/Relational/Boolean
 
-###This library is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT)###
+### This library is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT) ###


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
